### PR TITLE
Update misc.dm

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -1,6 +1,6 @@
 /obj/item/melee/chainofcommand
 	name = "chain of command"
-	desc = "A tool used by great men to placate the frothing masses."
+	desc = "A ceremonial length of chain, attached to a wooden handle. Representing how every Head of Staff is a link in the chain, these chains 'coincedentally' make for handy emergency weapons."
 	icon_state = "chain"
 	icon = 'icons/obj/weapons.dmi'
 	slot_flags = SLOT_BELT
@@ -124,7 +124,7 @@
 
 /obj/item/melee/skateboard/improv
 	name = "improvised skateboard"
-	desc = "A skateboard. It can be placed on its wheels and ridden, or used as a radical weapon."
+	desc = "A skateboard. Only humans would think to strap tiny wheels onto a plank of wood and call that 'transportation'. Grinding on rails ever since 1959."
 	icon_state = "skateboard"
 	icon = 'icons/obj/weapons.dmi'
 	slot_flags = SLOT_BELT
@@ -146,7 +146,7 @@
 
 /obj/item/melee/skateboard/hoverboard
 	name = "hoverboard"
-	desc = "A blast from the past, so retro!"
+	desc = "Utilizing the latest in miniature hoverjet technology, it takes a great deal of skill to ride a FlyGuy hoverboard. Use with caution."
 	icon_state = "hoverboard_red"
 	board_item_type = /obj/vehicle_old/skateboard/hoverboard
 
@@ -404,7 +404,7 @@
 #define FUEL_BURN_INTERVAL 15
 /obj/item/melee/thermalcutter
 	name = "thermal cutter"
-	desc = "Used by Tyrmalin scrappers to slice trough old space-hulks and robots alike."
+	desc = "Used by Tyrmalin scrappers to slice through old space-hulks and robots alike."
 	icon_state = "thermalcutter"
 	item_state = "thermalcutter"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_PHORON = 3, TECH_ENGINEERING = 4)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Finally getting around to making the in-game item descriptions less of a meme.

## Why It's Good For The Game

As much as levity is useful for this setting, meme descriptions and the like don't really fit the setting. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
tweak: tweaked a few things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
